### PR TITLE
Uses retries (if needed) for the HEAD requests to get the download file size

### DIFF
--- a/main.go
+++ b/main.go
@@ -148,12 +148,12 @@ func (d *Downloader) getDownloadSize(ctx context.Context, u string) (int64, erro
 		return 0, fmt.Errorf("got unexpected http response status for %s: %s", u, resp.Status)
 	}
 	if resp.ContentLength <= 0 {
-		if resp.Header.Get("Content-Range") == "" {
-			// TODO: find a way to throw an error on no-content with keeping the tests run as usual
-			return 0, nil
-		}
 		var s int64
-		p := strings.Split(resp.Header.Get("Content-Range"), "/")
+		r := strings.TrimSpace(resp.Header.Get("Content-Range"))
+		if r == "" {
+			return 0, fmt.Errorf("could not get content length for %s", u)
+		}
+		p := strings.Split(r, "/")
 		fmt.Sscan(p[len(p)-1], &s)
 		return s, nil
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -25,6 +25,7 @@ func TestDownload_Error(t *testing.T) {
 			s := httptest.NewServer(http.HandlerFunc(
 				func(w http.ResponseWriter, r *http.Request) {
 					if r.Method == http.MethodHead {
+						w.Header().Add("Content-Length", "2")
 						return
 					}
 					tc.proc(w)
@@ -161,6 +162,7 @@ func TestDownloadWithContext_ErrorUserTimeout(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == http.MethodHead {
+				w.Header().Add("Content-Length", "2")
 				return
 			}
 			time.Sleep(2 * userTimeout) // this time is greater than the user timeout, but shorter than the timeout per chunk.
@@ -277,12 +279,7 @@ func TestGetDownloadSize_NoContent(t *testing.T) {
 	defer s.Close()
 
 	d := DefaultDownloader()
-	got, err := d.getDownloadSize(context.Background(), s.URL)
-
-	if err != nil {
-		t.Errorf("expected no error getting the file size, got %s", err)
-	}
-	if got != 0 {
-		t.Errorf("invalid size, expected 0, got: %d", got)
+	if _, err := d.getDownloadSize(context.Background(), s.URL); err == nil {
+		t.Error("expected error getting the file size, got nil")
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -196,7 +196,7 @@ func TestDownload_Chunks(t *testing.T) {
 	d.ChunkSize = 5
 	got := d.chunks(12)
 	chunks := []chunk{{0, 4}, {5, 9}, {10, 11}}
-	sizes := []uint64{5, 5, 2}
+	sizes := []int64{5, 5, 2}
 	headers := []string{"bytes=0-4", "bytes=5-9", "bytes=10-11"}
 	if len(got) != len(chunks) {
 		t.Errorf("expected %d chunks, got %d", len(chunks), len(got))

--- a/progress.go
+++ b/progress.go
@@ -19,7 +19,7 @@ type progress struct {
 	// download fields so the encoder/decoder has access to them
 	URL       string
 	Path      string
-	ChunkSize uint64
+	ChunkSize int64
 	Chunks    []uint32
 }
 
@@ -123,7 +123,7 @@ func (p *progress) close() error {
 	return nil // Either not empty or error, suits both cases
 }
 
-func newProgress(path, url string, chunkSize uint64, chunks int, restart bool) (*progress, error) {
+func newProgress(path, url string, chunkSize int64, chunks int, restart bool) (*progress, error) {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return nil, fmt.Errorf("error getting absolute path for %s: %w", path, err)


### PR DESCRIPTION
I wrapped the request and the HTTP status check on the retry block, so we only proceed if there's no error and the HTTP status is OK.

This branch has two commits from #21 because the HEAD request behaviour needed the same fixes as there.

I decided to change uint64 to int64 because I've found out that an error in conversion would make debugging way more difficult. Happy to revert that once the package is more stable.