### PR TITLE
Parallel downloads

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	DefaultTimeoutPerChunk               = 90 * time.Second
-	DefaultMaxParallelDownloadsPerServer = 100
+	DefaultMaxParallelDownloadsPerServer = 8
 	DefaultMaxRetriesPerChunk            = 5
 	DefaultChunkSize                     = 8192
 	DefaultWaitBetweenRetries            = 0 * time.Minute

--- a/downloader.go
+++ b/downloader.go
@@ -161,7 +161,7 @@ func (d *Downloader) getDownloadSize(ctx context.Context, u string) (int64, erro
 			ch <- resp
 			return nil
 		},
-		retry.Attempts(d.MaxParallelDownloadsPerServer),
+		retry.Attempts(d.MaxRetriesPerChunk),
 		retry.MaxDelay(d.WaitBetweenRetries),
 	)
 	if err != nil {

--- a/downloader.go
+++ b/downloader.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	DefaultTimeoutPerChunk               = 90 * time.Second
-	DefaultMaxParallelDownloadsPerServer = 8
+	DefaultMaxParallelDownloadsPerServer = 100
 	DefaultMaxRetriesPerChunk            = 5
 	DefaultChunkSize                     = 8192
 	DefaultWaitBetweenRetries            = 0 * time.Minute
@@ -69,7 +69,7 @@ type Downloader struct {
 	// this is the total of parallel requests. If the user is downloading files
 	// from different servers (including different subdomains), this limit is
 	// applied to each server idependently.
-	MaxParallelDownloadsPerServer uint
+	MaxParallelDownloadsPerServer int
 
 	// MaxRetriesPerChunk is the maximum amount of retries for each HTTP request
 	// using the content range header that fails.
@@ -143,17 +143,17 @@ func (d *Downloader) downloadChunkWithTimeout(userCtx context.Context, u string,
 }
 
 func (d *Downloader) getDownloadSize(ctx context.Context, u string) (int64, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, u, nil)
-	if err != nil {
-		return 0, fmt.Errorf("creating the request for %s: %w", u, err)
-	}
 	ch := make(chan *http.Response, 1)
 	defer close(ch)
-	err = retry.Do(
+	err := retry.Do(
 		func() error {
+			req, err := http.NewRequestWithContext(ctx, http.MethodHead, u, nil)
+			if err != nil {
+				return fmt.Errorf("creating the request for %s: %w", u, err)
+			}
 			resp, err := d.client.Do(req)
 			if err != nil {
-				return err
+				return fmt.Errorf("dispatching the request for %s: %w", u, err)
 			}
 			if resp.StatusCode != 200 {
 				return fmt.Errorf("got unexpected http response status for %s: %s", u, resp.Status)
@@ -223,7 +223,6 @@ func (d *Downloader) chunks(t int64) []chunk {
 }
 
 func (d *Downloader) prepareAndStartDownload(ctx context.Context, url string, wg *sync.WaitGroup, ch chan<- DownloadStatus) {
-	defer wg.Done()
 	path := filepath.Join(os.TempDir(), filepath.Base(url))
 	s := DownloadStatus{URL: url, DownloadedFilePath: path}
 	t, err := d.getDownloadSize(ctx, url)
@@ -240,41 +239,51 @@ func (d *Downloader) prepareAndStartDownload(ctx context.Context, url string, wg
 		ch <- s
 		return
 	}
-	defer f.Close()
 	if err := f.Truncate(int64(t)); err != nil {
 		s.Error = fmt.Errorf("error truncating %s to %d: %w", path, t, err)
 		ch <- s
+		wg.Done()
 		return
 	}
+	var urlDownload sync.WaitGroup
 	for _, c := range d.chunks(t) {
-		b, err := d.downloadChunk(ctx, url, c)
-		if err != nil {
-			s.Error = err
+		urlDownload.Add(1)
+		go func(c chunk) {
+			defer urlDownload.Done()
+			b, err := d.downloadChunk(ctx, url, c)
+			if err != nil {
+				s.Error = err
+				ch <- s
+				return
+			}
+			_, err = f.WriteAt(b, int64(c.start))
+			if err != nil {
+				s.Error = fmt.Errorf("error writing to %s: %w", path, err)
+				ch <- s
+				return
+			}
+			s.DownloadedFileBytes += int64(len(b))
 			ch <- s
-			return
-		}
-		_, err = f.WriteAt(b, int64(c.start))
-		if err != nil {
-			s.Error = fmt.Errorf("error writing to %s: %w", path, err)
-			ch <- s
-			return
-		}
-		s.DownloadedFileBytes += int64(len(b))
-		ch <- s
+		}(c)
 	}
+	go func() {
+		urlDownload.Wait()
+		wg.Done()
+		f.Close()
+	}()
 }
 
 // DownloadWithContext is a version of Download that takes a context. The
 // context can be used to stop all downloads in progress.
 func (d *Downloader) DownloadWithContext(ctx context.Context, urls ...string) <-chan DownloadStatus {
 	if d.client == nil {
-		d.client = &http.Client{Timeout: d.TimeoutPerChunk}
+		d.client = newClient(d.MaxParallelDownloadsPerServer, d.TimeoutPerChunk)
 	}
-	ch := make(chan DownloadStatus)
-	var wg sync.WaitGroup
+	ch := make(chan DownloadStatus, 2*len(urls)) // the first status will be the total file size (and or an error creating/trucating the file).
+	var wg sync.WaitGroup                        // this wait group is used to wait for all chunks (from all downloads) to finish.
 	for _, u := range urls {
 		wg.Add(1)
-		go d.prepareAndStartDownload(ctx, u, &wg, ch)
+		d.prepareAndStartDownload(ctx, u, &wg, ch)
 	}
 	go func() {
 		wg.Wait()
@@ -292,14 +301,22 @@ func (d *Downloader) Download(urls ...string) <-chan DownloadStatus {
 // NewDownloader creates a downloader with the defalt configuration. Check
 // the constants in this package for their values.
 func DefaultDownloader() *Downloader {
-	d := Downloader{
+	return &Downloader{
 		TimeoutPerChunk:               DefaultTimeoutPerChunk,
 		MaxParallelDownloadsPerServer: DefaultMaxParallelDownloadsPerServer,
 		MaxRetriesPerChunk:            DefaultMaxRetriesPerChunk,
 		ChunkSize:                     DefaultChunkSize,
 		WaitBetweenRetries:            DefaultWaitBetweenRetries,
+		client:                        newClient(DefaultMaxRetriesPerChunk, DefaultTimeoutPerChunk),
 	}
-	d.client = &http.Client{Timeout: d.TimeoutPerChunk}
+}
 
-	return &d
+func newClient(maxParallelDownloadsPerServer int, timeoutPerChunk time.Duration) *http.Client {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.MaxConnsPerHost = maxParallelDownloadsPerServer
+	t.MaxIdleConnsPerHost = maxParallelDownloadsPerServer
+	return &http.Client{
+		Timeout:   timeoutPerChunk,
+		Transport: t,
+	}
 }

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -246,7 +246,6 @@ func TestGetDownloadSize_WithRetry(t *testing.T) {
 	attempts := int32(0)
 	s := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			fmt.Printf("attempts = %d\n", atomic.LoadInt32(&attempts)) // TODO: remove
 			if atomic.CompareAndSwapInt32(&attempts, 0, 1) {
 				w.WriteHeader(http.StatusTooManyRequests)
 				return
@@ -257,8 +256,6 @@ func TestGetDownloadSize_WithRetry(t *testing.T) {
 	defer s.Close()
 
 	d := DefaultDownloader()
-	fmt.Printf("d.MaxRetriesPerChunk = %d\n", d.MaxRetriesPerChunk) // TODO: remove
-	fmt.Printf("d.WaitBetweenRetries = %v\n", d.WaitBetweenRetries) // TODO: remove
 	got, err := d.getDownloadSize(context.Background(), s.URL)
 
 	if err != nil {


### PR DESCRIPTION
Implements the functionality of downloading chunks in parallel. It limits the number of concurrent connections (active downloads) per server through the HTTP transport.