### PR TITLE
Cleans up `README.md` for 1st release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,51 @@
 [![Tests](https://github.com/cuducos/chunk/actions/workflows/tests.yaml/badge.svg)](https://github.com/cuducos/chunk/actions/workflows/tests.yaml)
 [![Format](https://github.com/cuducos/chunk/actions/workflows/gofmt.yaml/badge.svg)](https://github.com/cuducos/chunk/actions/workflows/gofmt.yaml)
 [![Lint](https://github.com/cuducos/chunk/actions/workflows/golint.yaml/badge.svg)](https://github.com/cuducos/chunk/actions/workflows/golint.yaml)
+[![GoDoc](https://godoc.org/github.com/cuducos/chunk?status.svg)](https://godoc.org/github.com/cuducos/chunk)
 
 Chunk a download tool for slow and unstable servers.
 
-The idea of the project emerged as it was difficult for [Minha Receita](https://github.com/cuducos/minha-receita) to handle the download of [37 files that adds up to just approx. 5Gb](https://www.gov.br/receitafederal/pt-br/assuntos/orientacao-tributaria/cadastros/consultas/dados-publicos-cnpj). Most of the download solutions out there (e.g. [`got`](https://github.com/melbahja/got)) seem to be prepared for downloading large files, not for downloading from slow and unstable servers — which is the case at hand.
+## Usage
 
-## Main fetaures
+### CLI
+
+Install it with `go install github.com/cuducos/chunk` then:
+
+```console
+$ chunk <URLs>
+```
+
+Use `--help` for detailed instructions.
+
+### API
+
+The [`Download`](https://pkg.go.dev/github.com/cuducos/chunk#Download) method returns a channel with [`DownloadStatus`](https://pkg.go.dev/github.com/cuducos/chunk#DownloadStatus) statuses. This channel is closed once all downloads are finished, but the user is in charge of handling errors.
+
+#### Simplest use case
+
+```go
+d := chunk.DefaultDownloader()
+ch := d.Dowload(urls)
+```
+
+#### Customizing some options
+
+```go
+d := chunk.DefaultDownloader()
+d.MaxRetries = 42
+ch := d.Dowload(urls)
+```
+
+#### Customizing everything
+
+```go
+d := chunk.Downloader{...}
+ch := d.Download(urls)
+```
+
+## How?
+
+It uses HTTP range requests, retries per HTTP request (not per file), prevents re-downloading the same content range and supports wait time to give servers time to recover.
 
 ### Download using HTTP range requests
 
@@ -16,7 +55,7 @@ In order to complete downloads from slow and unstable servers, the download shou
 
 ### Retries by chunk, not by file
 
-In order to be quicker and avoid rework, the primary way to handle failure is to retry that “chunk” (that bytes range), not the whole file.
+In order to be quicker and avoid rework, the primary way to handle failure is to retry that “chunk” (content range), not the whole file.
 
 ### Control of which chunks are already downloaded
 
@@ -24,84 +63,9 @@ In order to avoid re-starting from the beginning in case of non-handled errors, 
 
 ### Detect server failures and give it a break
 
-In order to avoid unnecessary stress on the server, `chunk` relies not only on HTTP responses but also on other signs that the connection is stale and can:
+In order to avoid unnecessary stress on the server, `chunk` relies not only on HTTP responses but also on other signs that the connection is stale and can recover from that and give the server some time to recover from stress.
 
-1. recover from that and
-2. give the server some time to recover from stress.
+## Why?
 
-## Tech design
+The idea of the project emerged as it was difficult for [Minha Receita](https://github.com/cuducos/minha-receita) to handle the download of [37 files that adds up to just approx. 5Gb](https://www.gov.br/receitafederal/pt-br/assuntos/orientacao-tributaria/cadastros/consultas/dados-publicos-cnpj). Most of the download solutions out there (e.g. [`got`](https://github.com/melbahja/got)) seem to be prepared for downloading large files, not for downloading from slow and unstable servers — which is the case at hand.
 
-### Input
-
-* List of URLs
-* Directory where to save the files
-* Configuration (they can have defaults and be optional; customizing them can be a stretch goal):
-  * Chunck download attempt timeout
-  * Maximum parallel connection to each server
-  * Max retries per chunk (must have an option to unlimited)
-  * Range maximum size (chunk size)
-  * Time to wait on server failure
-
-### Prepare downloads
-
-For each URL of the list (this can be done in parallel):
-
-* Make sure the server accepts HTTP range requests (stretch goal)
-  * Can fail if it doesn't
-  * Or can default to regular HTTP request to download
-* Find out the file total size
-* Determine all the chunks to be downloaded (each start and end bytes)
-* Read or create a temporary control of chunks downloaded and pending chunks
-* Enqueue all the pending chunks
-
-With all this information, show a progress bar with the total work remaining.
-
-### Download
-
-* Set a timeout
-* Start the HTTP range request
-* In case of failure or timeout, re-queue this chunk
-* In case of success, send the chunk contents to a `results` channel
-
-### Writing files
-
-* Read the bytes from the `results` channel
-* Write to the file on disk
-* Update a progress bar to give the user an idea about the status of the downloads
-
-## Prototype
-
-The prototype is a CLI that wraps a GET HTTP request in a 45s timeout independent of the HTTP client's timeout. It also includes 3 retries by default.
-
-```console
-$ go run main.go <URL> # e.g. go run main.go https://github.com/cuducos/chunk/archive/refs/heads/main.zip
-```
-
-The API should work like this:
-
-```go
-// simple use case
-d := NewDownloader()
-ch := d.Dowload(urls)
-
-// partial customization
-d := NewDownloader()
-d.MaxRetriesPerChunk = 42
-ch := d.Dowload(urls)
-
-// full control
-d := chunk.Downloader{...}
-ch := d.Download(urls)
-```
-
-The resulting channel will transmit data about each download:
-
-```go
-type DownloadStatus struct {
-	URL                 string
-	DownloadedFilePath  string
-	FileSizeBytes       uint64
-	DownloadedFileBytes uint64
-	Error               error
-}
-```


### PR DESCRIPTION
Here I suggest some edits on the `README.md` to prepare the repo for its initial release. Mostly, the rationale is:

1. Link to the (forthcoming) Go package docs
2. Bring usage examples to the top
3. Keep things we know are changing in the near future (e.g. the CLI and struct renames for the `Downloaders` as well as changes from #8)

No need to merge now, just leaving it here for when we're ready.