### PR TITLE
Moves progress files to `~/.chunk`

### DIFF
--- a/progress_test.go
+++ b/progress_test.go
@@ -32,9 +32,6 @@ func TestProgress_FromScratch(t *testing.T) {
 			}
 		}
 	}
-	if err := p.close(); err != nil {
-		t.Errorf("expected no errors saving the progress file, got %s", err)
-	}
 	if _, err := os.ReadFile(p.path); err != nil {
 		t.Errorf("expected no errors reading the progress file, got %s", err)
 	}
@@ -63,12 +60,6 @@ func TestProgress_ParallelComplete(t *testing.T) {
 		}
 	}
 	close(errs)
-	if err := p.close(); err != nil {
-		t.Errorf("expected no errors removing the progress file, got %s", err)
-	}
-	if _, err := os.ReadFile(p.path); !os.IsNotExist(err) {
-		t.Errorf("expected progress file not to exist, rediong it returned error %s", err)
-	}
 }
 
 func TestProgress_FromFile(t *testing.T) {
@@ -79,8 +70,6 @@ func TestProgress_FromFile(t *testing.T) {
 		t.Errorf("expected no error creating the old progress, got %s", err)
 	}
 	old.done(1)
-	old.close()
-
 	p, err := newProgress(name, "https://test.etc/chunk.zip", 5, 3, false)
 	if err != nil {
 		t.Errorf("expected no error creating the progress, got %s", err)
@@ -100,9 +89,6 @@ func TestProgress_FromFile(t *testing.T) {
 			}
 		}
 	}
-	if err := p.close(); err != nil {
-		t.Errorf("expected no errors saving the progress file, got %s", err)
-	}
 	if _, err := os.ReadFile(p.path); err != nil {
 		t.Errorf("expected no errors reading the progress file, got %s", err)
 	}
@@ -116,8 +102,6 @@ func TestProgress_FromFileWithInvalidChunkSize(t *testing.T) {
 		t.Errorf("expected no error creating the old progress, got %s", err)
 	}
 	old.done(1)
-	old.close()
-
 	if _, err := newProgress(name, "https://test.etc/chunk.zip", 10, 3, false); err == nil {
 		t.Error("expected error creating the progress with different chunk size")
 	}
@@ -131,8 +115,6 @@ func TestProgress_FromFileWithRestart(t *testing.T) {
 		t.Errorf("expected no error creating the old progress, got %s", err)
 	}
 	old.done(1)
-	old.close()
-
 	p, err := newProgress(name, "https://test.etc/chunk.zip", 10, 3, true)
 	if err != nil {
 		t.Errorf("expected no error creating the progress, got %s", err)

--- a/progress_test.go
+++ b/progress_test.go
@@ -32,6 +32,9 @@ func TestProgress_FromScratch(t *testing.T) {
 			}
 		}
 	}
+	if err := p.close(); err != nil {
+		t.Errorf("expected no errors saving the progress file, got %s", err)
+	}
 	if _, err := os.ReadFile(p.path); err != nil {
 		t.Errorf("expected no errors reading the progress file, got %s", err)
 	}
@@ -60,6 +63,12 @@ func TestProgress_ParallelComplete(t *testing.T) {
 		}
 	}
 	close(errs)
+	if err := p.close(); err != nil {
+		t.Errorf("expected no errors removing the progress file, got %s", err)
+	}
+	if _, err := os.ReadFile(p.path); !os.IsNotExist(err) {
+		t.Errorf("expected progress file not to exist, rediong it returned error %s", err)
+	}
 }
 
 func TestProgress_FromFile(t *testing.T) {
@@ -70,6 +79,8 @@ func TestProgress_FromFile(t *testing.T) {
 		t.Errorf("expected no error creating the old progress, got %s", err)
 	}
 	old.done(1)
+	old.close()
+
 	p, err := newProgress(name, "https://test.etc/chunk.zip", 5, 3, false)
 	if err != nil {
 		t.Errorf("expected no error creating the progress, got %s", err)
@@ -89,6 +100,9 @@ func TestProgress_FromFile(t *testing.T) {
 			}
 		}
 	}
+	if err := p.close(); err != nil {
+		t.Errorf("expected no errors saving the progress file, got %s", err)
+	}
 	if _, err := os.ReadFile(p.path); err != nil {
 		t.Errorf("expected no errors reading the progress file, got %s", err)
 	}
@@ -102,6 +116,8 @@ func TestProgress_FromFileWithInvalidChunkSize(t *testing.T) {
 		t.Errorf("expected no error creating the old progress, got %s", err)
 	}
 	old.done(1)
+	old.close()
+
 	if _, err := newProgress(name, "https://test.etc/chunk.zip", 10, 3, false); err == nil {
 		t.Error("expected error creating the progress with different chunk size")
 	}
@@ -115,6 +131,8 @@ func TestProgress_FromFileWithRestart(t *testing.T) {
 		t.Errorf("expected no error creating the old progress, got %s", err)
 	}
 	old.done(1)
+	old.close()
+
 	p, err := newProgress(name, "https://test.etc/chunk.zip", 10, 3, true)
 	if err != nil {
 		t.Errorf("expected no error creating the progress, got %s", err)


### PR DESCRIPTION
As it is the `progress` control would create a hidden file in the `outputDir` of each download. This seems reasonable but would create situations as such:

* A user starts to download two files `https://server.etc/file1.zip` and `https://server.etc/file2.zip`
* One of the files is completed, but the other is not and the process is stopped
* `file1.zip` progress file would be removed since it was completed
* Restarting the download with the same command would re-download `file1.zip` unnecessarily (because it would have no progress file)

This PR suggests:
1.  moving all progress files to a predictable location, a hidden directory under the user's directory (i.e. `~/.chunk`)
2. all progress files names are unique to each combination of download URL and absolute local file path

This decision of uniqueness by URL **and** absolute file path allows the following scenarios:
* I downloaded the file `https://server.etc/file1.zip` today to `~/2022-11/file.zip`
* If the server changes the contents of the file, for example, monthly, I can download the new version to `~/2022-12/file1.zip` next month (this is exactly the use case for _Minha Receita_)

TODO in a follow up PR:
* add a field on the `Downloader` struct to ignore existing progresses 
* add an option such as `--discard-previous-downloads` (terrible naming, any ideas?) to start a downloader deleting the `~/.chunk/` progress files related to that downloads.