### PR TITLE
Adds user-agent customization option

### DIFF
--- a/cmd/chunk/main.go
+++ b/cmd/chunk/main.go
@@ -48,6 +48,7 @@ var rootCmd = &cobra.Command{
 		chunk.ChunkSize = chunkSize
 		chunk.RestartDownloads = restartDownloads
 		chunk.ProgressDir = progressDir
+		chunk.UserAgent = userAgent
 		prog := newProgress()
 		for status := range chunk.Download(args...) {
 			if status.Error != nil {
@@ -69,6 +70,7 @@ var (
 	waitBetweenRetries   time.Duration
 	restartDownloads     bool
 	progressDir          string
+	userAgent            string
 )
 
 func init() {
@@ -86,6 +88,7 @@ func init() {
 		"",
 		fmt.Sprintf("directory where to track progress; %s under user's home directory if blank, or CHUNK_DIR environment variable", chunk.DefaultChunkDir),
 	)
+	rootCmd.Flags().StringVarP(&userAgent, "user-agent", "u", chunk.DefaultUserAgent, "user agent to use in HTTP requests")
 }
 
 func main() {

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -299,6 +299,21 @@ func TestDownload_Chunks(t *testing.T) {
 	}
 }
 
+func TestGetDownload_WithUserAgent(t *testing.T) {
+	ua := "Answer/42.0"
+	s := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.UserAgent() != ua {
+				t.Errorf("expected user-agent to be %s, got %s", ua, r.UserAgent())
+			}
+		},
+	))
+	defer s.Close()
+	d := DefaultDownloader()
+	d.UserAgent = ua
+	<-d.Download(s.URL)
+}
+
 func TestGetDownloadSize_ContentLength(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This adds the possibility for users of the CLI and package to set a custom user-agent for all the HTTP requests handled by Chunk.