### PR TITLE
Reports already downloaded bytes as downloaded

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -289,6 +289,8 @@ func (d *Downloader) prepareAndStartDownload(ctx context.Context, url string, ch
 			return
 		}
 		if !pending {
+			s.DownloadedFileBytes = atomic.AddInt64(&downloadedBytes, c.size())
+			ch <- s
 			continue
 		}
 		urlDownload.Add(1)


### PR DESCRIPTION
As far as I got, we just send a `DownloadStatus` updating the total downloaded size if we try to download a chunk. This means that for chunks downloaded in previous runs, their bytes would be missing from the total count (i.e. `DownloadedFileBytes`). I am not sure whether this is intended or not.

- On the one hand, they are not downloaded in this run, so they might not be reported as they would mean something downloaded in another moment/context
- On the other hand, if we don't report them, the download will complete successfully, but `DownloadedFileBytes` will not match the expected file size in the last status

Since most of download managers count the bytes downloaded previously towards the total bytes downloaded, I suggest we add these lines. Any ideas? Any ideas about how to test that behavior?
